### PR TITLE
[DB] Extension de class users de Fortify — Issue 132 finalisée

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -58,7 +58,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
 
-        // ⭐ TON MIDDLEWARE DE RÔLE
         'role' => \App\Http\Middleware\RoleMiddleware::class,
     ];
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,6 +10,7 @@ class User extends Authenticatable
 {
     use Notifiable;
 
+
 protected $fillable = [
     'name',
     'email',
@@ -23,7 +24,6 @@ protected $fillable = [
     'idClasse',
     'role',
 ];
-
 
     protected $casts = [
         'email_verified_at' => 'datetime',

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
 
-            // 👉 Colonnes ajoutées (ancienne table)
+          
             $table->date('date_entree')->nullable();
             $table->string('telephone')->nullable();
             $table->string('spe')->nullable();


### PR DESCRIPTION
### **_Travail réalisé:_**
### **partie1:**
1- suppression de la migration "2026_02_23_134409_create_user_table.php"
2- conservation de la migration"0001-01-01-000000-create-users-table.php"
3- réinitialisation de la base de données avec la commande : php artisqn migrate:fresh --seed
**résultat:**
Dropping all tables ........................................ DONE
Preparing database.
Running migrations.
0001_01_01_000000_create_users_table .................. DONE
0001_01_01_000001_create_cache_table .................. DONE
0001_01_01_000002_create_jobs_table ................... DONE
2026_02_25_111246_add_two_factor_columns_to_users_table DONE
Seeding database.
vérification de la base de données 👍🏻 ( y a une seule table users )
**### partie2**
1- Ajout des colonnes de l’ancienne table dans la migration officielle users :(date_entree, telephone, spe, classe, promo, idTuteur, idClasse, role)
2-Mise à jour du modèle User pour inclure ces nouveaux attributs dans $fillable.
3-Migration fraîche de la base → la table users est maintenant propre, unique et contient toutes les colonnes nécessaires pour la suite.
4- création du middleware de rôle : j'ai crée un middleware "RoleMiddleware" qui permet de vérifier le rôle de l'utilisateur connecté , le middleware compare auth()->user()->role() avec le rôle exigé par la route , si le role ne correspond pas , laravel renvoie une erreur 403 (accès interdit)
5- enregistrement du middleware dans kernel.php
j'ai ajouté le middleware dans la section $routeMiddleware du fichier kernel.php:
"'role' => \App\Http\Middleware\RoleMiddleware::class,"
6-Protection des routes selon le rôle
Tests :
PS C:\Users\fatim\Desktop\gestage2> php artisan route:list
GET|HEAD prof/dashboard ...............................................
GET|HEAD admin/dashboard ..............................................
GET|HEAD etu/dashboard ................................................
**### partie3:**
_**L’ancien fonctionnement des rôles (avant Laravel)**_
Pour mieux comprendre, on va parler de l’ancien fonctionnement des rôles (avant Laravel). Avant l’intégration dans Laravel, l’application possédait une colonne status dans la table users qui servait à distinguer les types d’utilisateurs de l’application (prof ou élève). Donc l’accès aux pages dépendait directement de cette colonne.
_**Nouveau fonctionnement des rôles avec Laravel**_
Maintenant, avec Laravel, la gestion des rôles est déjà structurée dans la colonne role dans la table users. Cette colonne remplace l’ancienne « status » et permet de distinguer clairement le rôle de l’utilisateur : étudiant, professeur ou admin. Le modèle User a été modifié pour inclure cette colonne dans $fillable, ce qui permet à Laravel d’enregistrer et de modifier le rôle d’un utilisateur. Et on a créé un middleware RoleMiddleware afin de vérifier le rôle de l’utilisateur avant d’accéder à l’application. Donc Laravel peut maintenant gérer les rôles très facilement.
_**Contrôle de l’accès avec Laravel**_
Laravel utilise un middleware RoleMiddleware pour contrôler l’accès aux pages selon le rôle de l’utilisateur. Lorsqu’un utilisateur tente d’accéder à une route protégée, Laravel exécute d’abord le middleware, qui vérifie deux choses : si l’utilisateur est connecté (auth) et si son rôle correspond au rôle exigé par la route (ex : role:Professeur). Si le rôle ne correspond pas, Laravel bloque l’accès et renvoie une erreur 403 (accès interdit). Grâce à ce système, chaque espace de l’application peut être réservé à un type d’utilisateur, et cela permet de gérer proprement l’application