### PR TITLE
Erreur sur la syntaxe de Middleware, pas de s

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,15 +4,10 @@ use App\Http\Middleware\SetSecurityHeaders;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
-
-
 // Ajout Spatie
-use Spatie\Permission\Middlewares\RoleMiddleware;
-use Spatie\Permission\Middlewares\PermissionMiddleware;
-use Spatie\Permission\Middlewares\RoleOrPermissionMiddleware;
-
-
-
+use Spatie\Permission\Middleware\PermissionMiddleware;
+use Spatie\Permission\Middleware\RoleMiddleware;
+use Spatie\Permission\Middleware\RoleOrPermissionMiddleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -21,16 +16,14 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-     
-    
-    // Ajout du middleware de sécurité pour les en-têtes HTTP:
+
+        // Ajout du middleware de sécurité pour les en-têtes HTTP:
         $middleware->web(append: [
             SetSecurityHeaders::class,
         ]);
 
-
-        //enregistrement des middlewares de Spatie pour la gestion des rôles et permissions
-              $middleware->alias([
+        // enregistrement des middlewares de Spatie pour la gestion des rôles et permissions
+        $middleware->alias([
             'role' => RoleMiddleware::class,
             'permission' => PermissionMiddleware::class,
             'role_or_permission' => RoleOrPermissionMiddleware::class,


### PR DESCRIPTION
Rem:placement de:
use Spatie\Permission\Middlewares\PermissionMiddleware;
use Spatie\Permission\Middlewares\RoleMiddleware;
use Spatie\Permission\Middlewares\RoleOrPermissionMiddleware;

PAr use Spatie\Permission\Middleware\PermissionMiddleware;
use Spatie\Permission\Middleware\RoleMiddleware;
use Spatie\Permission\Middleware\RoleOrPermissionMiddleware;
