### PR TITLE
Refactors role-based redirection and logout

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -45,7 +45,7 @@ class CreateNewUser implements CreatesNewUsers
 
         session()->flash('status', 'Compte créé avec succès.');
 
-        return User::create([
+        $user = User::create([
             'nom' => $input['nom'],
             'prenom' => $input['prenom'],
             'email' => $input['email'],
@@ -65,5 +65,9 @@ class CreateNewUser implements CreatesNewUsers
             'dateFirstConn' => $input['dateFirstConn'] ?? null,
             'deleted' => $input['deleted'] ?? 0,
         ]);
+
+        $user->assignRole('Etudiant');
+
+        return $user;
     }
 }

--- a/app/Http/Controllers/RedirectController.php
+++ b/app/Http/Controllers/RedirectController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class RedirectController extends Controller
+{
+    /**
+     * Redirect the user to the appropriate dashboard based on their role.
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function index()
+    {
+        // 1. Si l'utilisateur n'est pas connecté (Visiteur)
+        if (! Auth::check()) {
+            return redirect('/login');
+        }
+
+        // 2. Si l'utilisateur est connecté, on récupère son profil
+        $user = Auth::user();
+
+        // 3. Redirections dynamiques basées sur les rôles Spatie
+        if ($user->hasRole('Administrateur')) {
+            return redirect('/admin');
+        }
+
+        if ($user->hasRole('Professeur')) {
+            return redirect('/dashboard');
+        }
+
+        if ($user->hasRole('Etudiant')) {
+            return redirect('/stages');
+        }
+
+        // Sécurité de repli si le compte a un bug de rôle
+        auth()->logout();
+
+        return redirect('/login')->withErrors(['erreur' => 'Votre compte ne possède aucun rôle.']);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,7 +23,6 @@ class User extends Authenticatable
         'promo',
         'idTuteur',
         'idClasse',
-        'role',
     ];
 
     protected $hidden = ['password', 'remember_token'];
@@ -35,19 +34,5 @@ class User extends Authenticatable
         'inactif' => 'boolean',
         'deleted' => 'boolean',
     ];
-
-    public function isProfesseur(): bool
-    {
-        return $this->role === 'Professeur';
-    }
-
-    public function isEtudiant(): bool
-    {
-        return $this->role === 'Etudiant';
-    }
-
-    public function isAdmin(): bool
-    {
-        return $this->role === 'Admin';
-    }
 }
+

--- a/resources/views/partials/navbar.blade.php
+++ b/resources/views/partials/navbar.blade.php
@@ -63,9 +63,15 @@
                                     <i class="fas fa-user-cog mr-2"></i> Mon Profil
                                 </a>
                                 <hr class="navbar-divider">
-                                <a href="/force-logout" class="navbar-item has-text-danger">
-                                    <i class="fas fa-sign-out-alt mr-2"></i> Déconnexion
-                                </a>
+                                {{-- Le lien de déconnexion est maintenant dans un formulaire pour la sécurité (POST + CSRF) --}}
+                                <form method="POST" action="{{ route('logout') }}">
+                                    @csrf
+                                    <a href="{{ route('logout') }}"
+                                       onclick="event.preventDefault(); this.closest('form').submit();"
+                                       class="navbar-item has-text-danger">
+                                        <i class="fas fa-sign-out-alt mr-2"></i> Déconnexion
+                                    </a>
+                                </form>
                             </div>
                         </div>
                     @endauth

--- a/routes/fortify.php
+++ b/routes/fortify.php
@@ -1,21 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use Laravel\Fortify\Http\Controllers\AuthenticatedSessionController;
-use Laravel\Fortify\Http\Controllers\RegisteredUserController;
-
-// Login
-Route::get('/login', [AuthenticatedSessionController::class, 'create'])
-    ->middleware('guest')
-    ->name('login');
-
-Route::post('/login', [AuthenticatedSessionController::class, 'store'])
-    ->middleware('guest');
-
-// Register
-Route::get('/register', [RegisteredUserController::class, 'create'])
-    ->middleware('guest')
-    ->name('register');
-
-Route::post('/register', [RegisteredUserController::class, 'store'])
-    ->middleware('guest');
+// Ce fichier est intentionnellement laissé vide.
+// Les routes d'authentification (login, register, etc.) sont gérées
+// automatiquement par Laravel Fortify grâce à la configuration
+// présente dans config/fortify.php ('views' => true).
+//
+// Garder ce fichier assure que le RouteServiceProvider ne casse pas
+// s'il tente de le charger, mais évite la redondance de routes.

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,37 +1,11 @@
 <?php
 
+use App\Http\Controllers\RedirectController;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route; // <- Import très important
 
 // --- L'AIGUILLEUR PRINCIPAL (Racine du site) ---
-Route::get('/', function () {
-
-    // 1. Si l'utilisateur n'est pas connecté (Visiteur)
-    if (! Auth::check()) {
-        return redirect('/login');
-    }
-
-    // 2. Si l'utilisateur est connecté, on récupère son profil
-    $user = Auth::user();
-
-    // 3. Redirections dynamiques basées sur les rôles Spatie
-    if ($user->hasRole('Administrateur')) {
-        return redirect('/admin');
-    }
-
-    if ($user->hasRole('Professeur')) {
-        return redirect('/dashboard');
-    }
-
-    if ($user->hasRole('Etudiant')) {
-        return redirect('/stages');
-    }
-
-    // Sécurité de repli si le compte a un bug de rôle
-    auth()->logout();
-
-    return redirect('/login')->withErrors(['erreur' => 'Votre compte ne possède aucun rôle.']);
-});
+Route::get('/', [RedirectController::class, 'index']);
 
 // Espace professeur (Synchronisé avec LoginResponse)
 Route::middleware(['auth', 'role:Professeur'])->group(function () {
@@ -54,12 +28,3 @@ Route::middleware(['auth', 'role:Administrateur'])->group(function () {
     });
 });
 
-// Route de secours pour forcer la déconnexion lors des tests
-Route::get('/force-logout', function () {
-    auth()->logout();
-    session()->invalidate();
-    session()->regenerateToken();
-
-    return redirect('/login');
-
-});


### PR DESCRIPTION
Extracts the role-based dashboard redirection logic from the `web.php` root route into a dedicated `RedirectController`. This centralizes and improves the readability and maintainability of the user redirection flow.

Enhances security by converting the logout action from a GET request to a standard POST form, utilizing Laravel Fortify's `route('logout')` with CSRF protection. This removes the insecure `force-logout` route.

Cleans up `fortify.php` by removing explicit login/register route definitions, relying instead on Laravel Fortify's automatic route generation via configuration.